### PR TITLE
Updated weapon label format for weapons such as rifles

### DIFF
--- a/Assets/Scripts/UI/HUD.cs
+++ b/Assets/Scripts/UI/HUD.cs
@@ -206,7 +206,16 @@ namespace SanAndreasUnity.UI {
 				this.weaponImage.texture = weaponTextureToDisplay;
 
 			this.weaponAmmoText.enabled = true;
-			string ammoText = weapon != null ? weapon.AmmoOutsideOfClip + "-" + weapon.AmmoInClip : string.Empty;
+			string ammoText = string.Empty;
+
+			if (weapon != null)
+			{
+				if (weapon.ReloadTime == 0f && weapon.AmmoClipSize == 1)
+					ammoText = weapon.TotalAmmo.ToString();
+				else
+					ammoText = $"{weapon.AmmoOutsideOfClip}-{weapon.AmmoInClip}";
+			}
+
 			if (this.weaponAmmoText.text != ammoText)
 				this.weaponAmmoText.text = ammoText;
 


### PR DESCRIPTION
Certain weapons like rifles can be shot indefinitely without reloading. In the original game in case of weapons like that, the weapon label displayed the total number of rounds available.

Currently weapon label is displayed in the following format - "{remaining number of rounds}-{number of rounds in the clip}". Made sure that weapons such as rifles would just display the total number of rounds available instead as in the original game.
