### PR TITLE
Implemented extra components selection for vehicles

### DIFF
--- a/Assets/Scripts/Behaviours/Vehicles/Vehicle_Spawning.cs
+++ b/Assets/Scripts/Behaviours/Vehicles/Vehicle_Spawning.cs
@@ -64,15 +64,15 @@ namespace SanAndreasUnity.Behaviours.Vehicles
             LeftRear,
         }
 
-		public enum VehicleComponentsRules
-		{
-			ALLOW_ALWAYS = 1,
-			ONLY_WHEN_RAINING = 2,
-			MAYBE_HIDE = 3,
-			FULL_RANDOM = 4,
-		}
+        public enum VehicleComponentsRules
+        {
+            ALLOW_ALWAYS = 1,
+            ONLY_WHEN_RAINING = 2,
+            MAYBE_HIDE = 3,
+            FULL_RANDOM = 4,
+        }
 
-		private static VehicleDef[] _sRandomSpawnable;
+        private static VehicleDef[] _sRandomSpawnable;
         private static int _sMaxSpawnableIndex;
 
         private static VehicleDef[] GetRandomSpawnableDefs(out int maxIndex)
@@ -295,11 +295,11 @@ namespace SanAndreasUnity.Behaviours.Vehicles
 
         private readonly List<Wheel> _wheels = new List<Wheel>();
         private readonly List<Seat> _seats = new List<Seat>();
-		private readonly List<Frame> _extras = new List<Frame>();
+        private readonly List<Frame> _extras = new List<Frame>();
 
-		public List<Wheel> Wheels { get { return _wheels; } }
+        public List<Wheel> Wheels { get { return _wheels; } }
         public List<Seat> Seats { get { return _seats; } }
-		public List<Frame> Extras { get { return _extras; } }
+        public List<Frame> Extras { get { return _extras; } }
 
         private WheelAlignment GetWheelAlignment(string frameName)
         {
@@ -415,10 +415,10 @@ namespace SanAndreasUnity.Behaviours.Vehicles
 
             foreach (var frame in _frames)
             {
-				if (frame.Name.StartsWith("extra"))
-				{
-					_extras.Add(frame);
-				}
+                if (frame.Name.StartsWith("extra"))
+                {
+                    _extras.Add(frame);
+                }
 
                 if (!frame.Name.StartsWith("wheel_")) continue;
                 if (!frame.Name.EndsWith("_dummy")) continue;
@@ -478,7 +478,7 @@ namespace SanAndreasUnity.Behaviours.Vehicles
                 }
             }
 
-			SelectExtras();
+            SelectExtras();
 
             InitializePhysics();
 
@@ -636,149 +636,149 @@ namespace SanAndreasUnity.Behaviours.Vehicles
             }
         }
 
-		private void SelectExtras()
-		{
-			int firstExtraIdx = -1;
-			int secondExtraIdx = -1;
+        private void SelectExtras()
+        {
+            int firstExtraIdx = -1;
+            int secondExtraIdx = -1;
 
-			VehicleDef.CompRulesUnion compsUnion = Definition.CompRules;
-			if (compsUnion.HasExtraOne())
-			{
-				firstExtraIdx = ChooseComponent(Definition.CompRules.nExtraARule, compsUnion.nExtraAComp);
-			}
+            VehicleDef.CompRulesUnion compsUnion = Definition.CompRules;
+            if (compsUnion.HasExtraOne())
+            {
+                firstExtraIdx = ChooseComponent(Definition.CompRules.nExtraARule, compsUnion.nExtraAComp);
+            }
 
-			if (compsUnion.HasExtraTwo())
-			{
-				firstExtraIdx = ChooseComponent(compsUnion.nExtraBRule, compsUnion.nExtraBComp);
-			}
+            if (compsUnion.HasExtraTwo())
+            {
+                firstExtraIdx = ChooseComponent(compsUnion.nExtraBRule, compsUnion.nExtraBComp);
+            }
 
-			foreach (var extra in Extras)
-			{
-				Boolean isFirstExtra = extra.Name == ("extra" + firstExtraIdx.ToString());
-				Boolean isSecondExtra = extra.Name == ("extra" + secondExtraIdx.ToString());
+            foreach (var extra in Extras)
+            {
+                Boolean isFirstExtra = extra.Name == ("extra" + firstExtraIdx.ToString());
+                Boolean isSecondExtra = extra.Name == ("extra" + secondExtraIdx.ToString());
 
-				extra.gameObject.SetActive(isFirstExtra || isSecondExtra);
-			}
-		}
+                extra.gameObject.SetActive(isFirstExtra || isSecondExtra);
+            }
+        }
 
-		private	int ChooseComponent(int rule, int comps)
-		{
-			VehicleDef.CompRulesUnion compsUnion = Definition.CompRules;
+        private    int ChooseComponent(int rule, int comps)
+        {
+            VehicleDef.CompRulesUnion compsUnion = Definition.CompRules;
 
-			if ((rule != 0) && IsValidCompRule(rule))
-			{
-				return ChooseComponentInternal(rule, comps);
-			}
-			else if (UnityEngine.Random.Range(0, 3) < 2)
-			{
-				int[] anVariations = new int[6];
-				int numComps = GetListOfComponentsNotUsedByRules(Extras.Count, anVariations);
-				if (numComps > 0)
-					return anVariations[UnityEngine.Random.Range(0, numComps)];
-			}
+            if ((rule != 0) && IsValidCompRule(rule))
+            {
+                return ChooseComponentInternal(rule, comps);
+            }
+            else if (UnityEngine.Random.Range(0, 3) < 2)
+            {
+                int[] anVariations = new int[6];
+                int numComps = GetListOfComponentsNotUsedByRules(Extras.Count, anVariations);
+                if (numComps > 0)
+                    return anVariations[UnityEngine.Random.Range(0, numComps)];
+            }
 
-			return -1;
-		}
+            return -1;
+        }
 
-		private bool IsValidCompRule(int nRule)
-		{
-			//	TODO add weather checking, when weather is implemented.
-			Boolean isRainingNow = false;
+        private bool IsValidCompRule(int nRule)
+        {
+            //    TODO add weather checking, when weather is implemented.
+            Boolean isRainingNow = false;
 
-			return (nRule != (int)VehicleComponentsRules.ONLY_WHEN_RAINING)
-				|| isRainingNow
-			;
-		}
+            return (nRule != (int)VehicleComponentsRules.ONLY_WHEN_RAINING)
+                || isRainingNow
+            ;
+        }
 
-		private int ChooseComponentInternal(int rule, int comps)
-		{
-			int component = -1;
-			if (rule == (int)VehicleComponentsRules.ALLOW_ALWAYS || 
-				rule == (int)VehicleComponentsRules.ONLY_WHEN_RAINING)
-			{
-				int iNumComps = CountCompsInRule(comps);
-				int rand = UnityEngine.Random.Range(0, iNumComps);
-				component = (comps >> (4 * rand)) & 0xF;
-			}
-			else if (rule == (int)VehicleComponentsRules.MAYBE_HIDE)
-			{
-				int iNumComps = CountCompsInRule(comps);
-				int rand = UnityEngine.Random.Range(-1, iNumComps);
-				if (rand != -1)
-					component = (comps >> (4 * rand)) & 0xF;
-			}
-			else if (rule == (int)VehicleComponentsRules.FULL_RANDOM)
-			{
-				component = UnityEngine.Random.Range(0, 5);
-			}
+        private int ChooseComponentInternal(int rule, int comps)
+        {
+            int component = -1;
+            if (rule == (int)VehicleComponentsRules.ALLOW_ALWAYS || 
+                rule == (int)VehicleComponentsRules.ONLY_WHEN_RAINING)
+            {
+                int iNumComps = CountCompsInRule(comps);
+                int rand = UnityEngine.Random.Range(0, iNumComps);
+                component = (comps >> (4 * rand)) & 0xF;
+            }
+            else if (rule == (int)VehicleComponentsRules.MAYBE_HIDE)
+            {
+                int iNumComps = CountCompsInRule(comps);
+                int rand = UnityEngine.Random.Range(-1, iNumComps);
+                if (rand != -1)
+                    component = (comps >> (4 * rand)) & 0xF;
+            }
+            else if (rule == (int)VehicleComponentsRules.FULL_RANDOM)
+            {
+                component = UnityEngine.Random.Range(0, 5);
+            }
 
-			return component;
-		}
+            return component;
+        }
 
-		int CountCompsInRule(int comps)
-		{
-			int result = 0;
-			while (comps != 0)
-			{
-				if ((comps & 0xF) != 0xF)
-					++result;
+        int CountCompsInRule(int comps)
+        {
+            int result = 0;
+            while (comps != 0)
+            {
+                if ((comps & 0xF) != 0xF)
+                    ++result;
 
-				int a = comps / 16;
-				int b = comps >> 4;
+                int a = comps / 16;
+                int b = comps >> 4;
 
-				comps >>= 4;
-			}
+                comps >>= 4;
+            }
 
-			return result;
-		}
+            return result;
+        }
 
-		int GetListOfComponentsNotUsedByRules(int numExtras, int[] outList)
-		{
-			int[] iCompsList = new int[]{ 0, 1, 2, 3, 4, 5 };
+        int GetListOfComponentsNotUsedByRules(int numExtras, int[] outList)
+        {
+            int[] iCompsList = new int[]{ 0, 1, 2, 3, 4, 5 };
 
-			VehicleDef.CompRulesUnion comps = Definition.CompRules;
+            VehicleDef.CompRulesUnion comps = Definition.CompRules;
 
-			if (comps.nExtraARule != 0 && IsValidCompRule(comps.nExtraARule))
-			{
-				if (comps.nExtraARule == (int)VehicleComponentsRules.FULL_RANDOM)
-					return 0;
+            if (comps.nExtraARule != 0 && IsValidCompRule(comps.nExtraARule))
+            {
+                if (comps.nExtraARule == (int)VehicleComponentsRules.FULL_RANDOM)
+                    return 0;
 
-				if (comps.nExtraA_comp1 != 0xF)
-					iCompsList[comps.nExtraA_comp1] = 0xF;
+                if (comps.nExtraA_comp1 != 0xF)
+                    iCompsList[comps.nExtraA_comp1] = 0xF;
 
-				if (comps.nExtraA_comp2 != 0xF)
-					iCompsList[comps.nExtraA_comp2] = 0xF;
+                if (comps.nExtraA_comp2 != 0xF)
+                    iCompsList[comps.nExtraA_comp2] = 0xF;
 
-				if (comps.nExtraA_comp3 != 0xF)
-					iCompsList[comps.nExtraA_comp3] = 0xF;
-			}
+                if (comps.nExtraA_comp3 != 0xF)
+                    iCompsList[comps.nExtraA_comp3] = 0xF;
+            }
 
-			if (comps.nExtraBRule != 0 && IsValidCompRule(comps.nExtraBRule))
-			{
-				if (comps.nExtraBRule == (int)VehicleComponentsRules.FULL_RANDOM)
-					return 0;
+            if (comps.nExtraBRule != 0 && IsValidCompRule(comps.nExtraBRule))
+            {
+                if (comps.nExtraBRule == (int)VehicleComponentsRules.FULL_RANDOM)
+                    return 0;
 
-				if (comps.nExtraB_comp1 != 0xF)
-					iCompsList[comps.nExtraA_comp1] = 0xF;
+                if (comps.nExtraB_comp1 != 0xF)
+                    iCompsList[comps.nExtraA_comp1] = 0xF;
 
-				if (comps.nExtraB_comp2 != 0xF)
-					iCompsList[comps.nExtraA_comp2] = 0xF;
+                if (comps.nExtraB_comp2 != 0xF)
+                    iCompsList[comps.nExtraA_comp2] = 0xF;
 
-				if (comps.nExtraB_comp3 != 0xF)
-					iCompsList[comps.nExtraA_comp3] = 0xF;
-			}
+                if (comps.nExtraB_comp3 != 0xF)
+                    iCompsList[comps.nExtraA_comp3] = 0xF;
+            }
 
-			int iNumComps = 0;
-			for (int i = 0; i < numExtras; ++i)
-			{
-				if (iCompsList[i] == 0xF)
-					continue;
+            int iNumComps = 0;
+            for (int i = 0; i < numExtras; ++i)
+            {
+                if (iCompsList[i] == 0xF)
+                    continue;
 
-				outList[iNumComps] = i;
-				++iNumComps;
-			}
+                outList[iNumComps] = i;
+                ++iNumComps;
+            }
 
-			return iNumComps;
-		}
-	}
+            return iNumComps;
+        }
+    }
 }

--- a/Assets/Scripts/Behaviours/Vehicles/Vehicle_Spawning.cs
+++ b/Assets/Scripts/Behaviours/Vehicles/Vehicle_Spawning.cs
@@ -661,7 +661,7 @@ namespace SanAndreasUnity.Behaviours.Vehicles
             }
         }
 
-        private    int ChooseComponent(int rule, int comps)
+        private int ChooseComponent(int rule, int comps)
         {
             VehicleDef.CompRulesUnion compsUnion = Definition.CompRules;
 
@@ -723,9 +723,6 @@ namespace SanAndreasUnity.Behaviours.Vehicles
                 if ((comps & 0xF) != 0xF)
                     ++result;
 
-                int a = comps / 16;
-                int b = comps >> 4;
-
                 comps >>= 4;
             }
 
@@ -759,13 +756,13 @@ namespace SanAndreasUnity.Behaviours.Vehicles
                     return 0;
 
                 if (comps.nExtraB_comp1 != 0xF)
-                    iCompsList[comps.nExtraA_comp1] = 0xF;
+                    iCompsList[comps.nExtraB_comp1] = 0xF;
 
                 if (comps.nExtraB_comp2 != 0xF)
-                    iCompsList[comps.nExtraA_comp2] = 0xF;
+                    iCompsList[comps.nExtraB_comp2] = 0xF;
 
                 if (comps.nExtraB_comp3 != 0xF)
-                    iCompsList[comps.nExtraA_comp3] = 0xF;
+                    iCompsList[comps.nExtraB_comp3] = 0xF;
             }
 
             int iNumComps = 0;

--- a/Assets/Scripts/Behaviours/Vehicles/Vehicle_Spawning.cs
+++ b/Assets/Scripts/Behaviours/Vehicles/Vehicle_Spawning.cs
@@ -64,7 +64,15 @@ namespace SanAndreasUnity.Behaviours.Vehicles
             LeftRear,
         }
 
-        private static VehicleDef[] _sRandomSpawnable;
+		public enum VehicleComponentsRules
+		{
+			ALLOW_ALWAYS = 1,
+			ONLY_WHEN_RAINING = 2,
+			MAYBE_HIDE = 3,
+			FULL_RANDOM = 4,
+		}
+
+		private static VehicleDef[] _sRandomSpawnable;
         private static int _sMaxSpawnableIndex;
 
         private static VehicleDef[] GetRandomSpawnableDefs(out int maxIndex)
@@ -287,9 +295,11 @@ namespace SanAndreasUnity.Behaviours.Vehicles
 
         private readonly List<Wheel> _wheels = new List<Wheel>();
         private readonly List<Seat> _seats = new List<Seat>();
+		private readonly List<Frame> _extras = new List<Frame>();
 
-        public List<Wheel> Wheels { get { return _wheels; } }
+		public List<Wheel> Wheels { get { return _wheels; } }
         public List<Seat> Seats { get { return _seats; } }
+		public List<Frame> Extras { get { return _extras; } }
 
         private WheelAlignment GetWheelAlignment(string frameName)
         {
@@ -405,6 +415,11 @@ namespace SanAndreasUnity.Behaviours.Vehicles
 
             foreach (var frame in _frames)
             {
+				if (frame.Name.StartsWith("extra"))
+				{
+					_extras.Add(frame);
+				}
+
                 if (!frame.Name.StartsWith("wheel_")) continue;
                 if (!frame.Name.EndsWith("_dummy")) continue;
 
@@ -462,6 +477,8 @@ namespace SanAndreasUnity.Behaviours.Vehicles
                     inst.Complement.Complement = inst;
                 }
             }
+
+			SelectExtras();
 
             InitializePhysics();
 
@@ -618,5 +635,150 @@ namespace SanAndreasUnity.Behaviours.Vehicles
                 hinge.connectedBody = gameObject.GetComponent<Rigidbody>();
             }
         }
-    }
+
+		private void SelectExtras()
+		{
+			int firstExtraIdx = -1;
+			int secondExtraIdx = -1;
+
+			VehicleDef.CompRulesUnion compsUnion = Definition.CompRules;
+			if (compsUnion.HasExtraOne())
+			{
+				firstExtraIdx = ChooseComponent(Definition.CompRules.nExtraARule, compsUnion.nExtraAComp);
+			}
+
+			if (compsUnion.HasExtraTwo())
+			{
+				firstExtraIdx = ChooseComponent(compsUnion.nExtraBRule, compsUnion.nExtraBComp);
+			}
+
+			foreach (var extra in Extras)
+			{
+				Boolean isFirstExtra = extra.Name == ("extra" + firstExtraIdx.ToString());
+				Boolean isSecondExtra = extra.Name == ("extra" + secondExtraIdx.ToString());
+
+				extra.gameObject.SetActive(isFirstExtra || isSecondExtra);
+			}
+		}
+
+		private	int ChooseComponent(int rule, int comps)
+		{
+			VehicleDef.CompRulesUnion compsUnion = Definition.CompRules;
+
+			if ((rule != 0) && IsValidCompRule(rule))
+			{
+				return ChooseComponentInternal(rule, comps);
+			}
+			else if (UnityEngine.Random.Range(0, 3) < 2)
+			{
+				int[] anVariations = new int[6];
+				int numComps = GetListOfComponentsNotUsedByRules(Extras.Count, anVariations);
+				if (numComps > 0)
+					return anVariations[UnityEngine.Random.Range(0, numComps)];
+			}
+
+			return -1;
+		}
+
+		private bool IsValidCompRule(int nRule)
+		{
+			//	TODO add weather checking, when weather is implemented.
+			Boolean isRainingNow = false;
+
+			return (nRule != (int)VehicleComponentsRules.ONLY_WHEN_RAINING)
+				|| isRainingNow
+			;
+		}
+
+		private int ChooseComponentInternal(int rule, int comps)
+		{
+			int component = -1;
+			if (rule == (int)VehicleComponentsRules.ALLOW_ALWAYS || 
+				rule == (int)VehicleComponentsRules.ONLY_WHEN_RAINING)
+			{
+				int iNumComps = CountCompsInRule(comps);
+				int rand = UnityEngine.Random.Range(0, iNumComps);
+				component = (comps >> (4 * rand)) & 0xF;
+			}
+			else if (rule == (int)VehicleComponentsRules.MAYBE_HIDE)
+			{
+				int iNumComps = CountCompsInRule(comps);
+				int rand = UnityEngine.Random.Range(-1, iNumComps);
+				if (rand != -1)
+					component = (comps >> (4 * rand)) & 0xF;
+			}
+			else if (rule == (int)VehicleComponentsRules.FULL_RANDOM)
+			{
+				component = UnityEngine.Random.Range(0, 5);
+			}
+
+			return component;
+		}
+
+		int CountCompsInRule(int comps)
+		{
+			int result = 0;
+			while (comps != 0)
+			{
+				if ((comps & 0xF) != 0xF)
+					++result;
+
+				int a = comps / 16;
+				int b = comps >> 4;
+
+				comps >>= 4;
+			}
+
+			return result;
+		}
+
+		int GetListOfComponentsNotUsedByRules(int numExtras, int[] outList)
+		{
+			int[] iCompsList = new int[]{ 0, 1, 2, 3, 4, 5 };
+
+			VehicleDef.CompRulesUnion comps = Definition.CompRules;
+
+			if (comps.nExtraARule != 0 && IsValidCompRule(comps.nExtraARule))
+			{
+				if (comps.nExtraARule == (int)VehicleComponentsRules.FULL_RANDOM)
+					return 0;
+
+				if (comps.nExtraA_comp1 != 0xF)
+					iCompsList[comps.nExtraA_comp1] = 0xF;
+
+				if (comps.nExtraA_comp2 != 0xF)
+					iCompsList[comps.nExtraA_comp2] = 0xF;
+
+				if (comps.nExtraA_comp3 != 0xF)
+					iCompsList[comps.nExtraA_comp3] = 0xF;
+			}
+
+			if (comps.nExtraBRule != 0 && IsValidCompRule(comps.nExtraBRule))
+			{
+				if (comps.nExtraBRule == (int)VehicleComponentsRules.FULL_RANDOM)
+					return 0;
+
+				if (comps.nExtraB_comp1 != 0xF)
+					iCompsList[comps.nExtraA_comp1] = 0xF;
+
+				if (comps.nExtraB_comp2 != 0xF)
+					iCompsList[comps.nExtraA_comp2] = 0xF;
+
+				if (comps.nExtraB_comp3 != 0xF)
+					iCompsList[comps.nExtraA_comp3] = 0xF;
+			}
+
+			int iNumComps = 0;
+			for (int i = 0; i < numExtras; ++i)
+			{
+				if (iCompsList[i] == 0xF)
+					continue;
+
+				outList[iNumComps] = i;
+				++iNumComps;
+			}
+
+			return iNumComps;
+		}
+	}
 }

--- a/Assets/Scripts/Importing/Items/Definitions/VehicleDef.cs
+++ b/Assets/Scripts/Importing/Items/Definitions/VehicleDef.cs
@@ -20,7 +20,56 @@ namespace SanAndreasUnity.Importing.Items.Definitions
     [Section("cars")]
     public class VehicleDef : Definition, IObjectDefinition
     {
-        public readonly int Id;
+		public struct CompRulesUnion
+		{
+			public int nExtraA_comp1;
+			public int nExtraA_comp2;
+			public int nExtraA_comp3;
+
+			public int nExtraB_comp1;
+			public int nExtraB_comp2;
+			public int nExtraB_comp3;
+
+			public int nExtraAComp;
+			public int nExtraARule;
+			public int nExtraBComp;
+			public int nExtraBRule;
+
+			public int nExtraA;
+			public int nExtraB;
+
+			public CompRulesUnion(int value)
+			{
+				nExtraA = (value & 0x0000FFFF) >> 0;
+				nExtraB = (int)(value & 0xFFFF0000) >> 16;
+
+				nExtraAComp = (nExtraA & 0x0FFF) >> 0;
+				nExtraARule = (nExtraA & 0xF000) >> 12;
+
+				nExtraBComp = (nExtraB & 0x0FFF) >> 0;
+				nExtraBRule = (nExtraB & 0xF000) >> 12;
+
+				nExtraA_comp1 = (nExtraA & 0x000F) >> 0;
+				nExtraA_comp2 = (nExtraA & 0x00F0) >> 4;
+				nExtraA_comp3 = (nExtraA & 0x0F00) >> 8;
+
+				nExtraB_comp1 = (nExtraB & 0x000F) >> 0;
+				nExtraB_comp2 = (nExtraB & 0x00F0) >> 4;
+				nExtraB_comp3 = (nExtraB & 0x0F00) >> 8;
+			}
+
+			public Boolean HasExtraOne()
+			{
+				return nExtraA != 0;
+			}
+
+			public Boolean HasExtraTwo()
+			{
+				return nExtraB != 0;
+			}
+		}
+
+		public readonly int Id;
 
         int IObjectDefinition.Id
         {
@@ -39,7 +88,7 @@ namespace SanAndreasUnity.Importing.Items.Definitions
 
         public readonly int Frequency;
         public readonly int Flags;
-        public readonly int CompRules;
+        public readonly CompRulesUnion CompRules;
 
         public readonly bool HasWheels;
 
@@ -65,7 +114,7 @@ namespace SanAndreasUnity.Importing.Items.Definitions
 
             Frequency = GetInt(8);
             Flags = GetInt(9);
-            CompRules = GetInt(10, NumberStyles.HexNumber);
+            CompRules = new CompRulesUnion(GetInt(10, NumberStyles.HexNumber));
 
             HasWheels = Parts >= 15;
 

--- a/Assets/Scripts/Importing/Items/Definitions/VehicleDef.cs
+++ b/Assets/Scripts/Importing/Items/Definitions/VehicleDef.cs
@@ -20,56 +20,56 @@ namespace SanAndreasUnity.Importing.Items.Definitions
     [Section("cars")]
     public class VehicleDef : Definition, IObjectDefinition
     {
-		public struct CompRulesUnion
-		{
-			public int nExtraA_comp1;
-			public int nExtraA_comp2;
-			public int nExtraA_comp3;
+        public struct CompRulesUnion
+        {
+            public int nExtraA_comp1;
+            public int nExtraA_comp2;
+            public int nExtraA_comp3;
 
-			public int nExtraB_comp1;
-			public int nExtraB_comp2;
-			public int nExtraB_comp3;
+            public int nExtraB_comp1;
+            public int nExtraB_comp2;
+            public int nExtraB_comp3;
 
-			public int nExtraAComp;
-			public int nExtraARule;
-			public int nExtraBComp;
-			public int nExtraBRule;
+            public int nExtraAComp;
+            public int nExtraARule;
+            public int nExtraBComp;
+            public int nExtraBRule;
 
-			public int nExtraA;
-			public int nExtraB;
+            public int nExtraA;
+            public int nExtraB;
 
-			public CompRulesUnion(int value)
-			{
-				nExtraA = (value & 0x0000FFFF) >> 0;
-				nExtraB = (int)(value & 0xFFFF0000) >> 16;
+            public CompRulesUnion(int value)
+            {
+                nExtraA = (value & 0x0000FFFF) >> 0;
+                nExtraB = (int)(value & 0xFFFF0000) >> 16;
 
-				nExtraAComp = (nExtraA & 0x0FFF) >> 0;
-				nExtraARule = (nExtraA & 0xF000) >> 12;
+                nExtraAComp = (nExtraA & 0x0FFF) >> 0;
+                nExtraARule = (nExtraA & 0xF000) >> 12;
 
-				nExtraBComp = (nExtraB & 0x0FFF) >> 0;
-				nExtraBRule = (nExtraB & 0xF000) >> 12;
+                nExtraBComp = (nExtraB & 0x0FFF) >> 0;
+                nExtraBRule = (nExtraB & 0xF000) >> 12;
 
-				nExtraA_comp1 = (nExtraA & 0x000F) >> 0;
-				nExtraA_comp2 = (nExtraA & 0x00F0) >> 4;
-				nExtraA_comp3 = (nExtraA & 0x0F00) >> 8;
+                nExtraA_comp1 = (nExtraA & 0x000F) >> 0;
+                nExtraA_comp2 = (nExtraA & 0x00F0) >> 4;
+                nExtraA_comp3 = (nExtraA & 0x0F00) >> 8;
 
-				nExtraB_comp1 = (nExtraB & 0x000F) >> 0;
-				nExtraB_comp2 = (nExtraB & 0x00F0) >> 4;
-				nExtraB_comp3 = (nExtraB & 0x0F00) >> 8;
-			}
+                nExtraB_comp1 = (nExtraB & 0x000F) >> 0;
+                nExtraB_comp2 = (nExtraB & 0x00F0) >> 4;
+                nExtraB_comp3 = (nExtraB & 0x0F00) >> 8;
+            }
 
-			public Boolean HasExtraOne()
-			{
-				return nExtraA != 0;
-			}
+            public Boolean HasExtraOne()
+            {
+                return nExtraA != 0;
+            }
 
-			public Boolean HasExtraTwo()
-			{
-				return nExtraB != 0;
-			}
-		}
+            public Boolean HasExtraTwo()
+            {
+                return nExtraB != 0;
+            }
+        }
 
-		public readonly int Id;
+        public readonly int Id;
 
         int IObjectDefinition.Id
         {

--- a/Assets/Scripts/Importing/Items/Definitions/VehicleDef.cs
+++ b/Assets/Scripts/Importing/Items/Definitions/VehicleDef.cs
@@ -22,40 +22,27 @@ namespace SanAndreasUnity.Importing.Items.Definitions
     {
         public struct CompRulesUnion
         {
-            public int nExtraA_comp1;
-            public int nExtraA_comp2;
-            public int nExtraA_comp3;
+            private int value;
 
-            public int nExtraB_comp1;
-            public int nExtraB_comp2;
-            public int nExtraB_comp3;
+            public int nExtraA_comp1 { get { return (nExtraA & 0x000F) >> 0; } }
+            public int nExtraA_comp2 { get { return (nExtraA & 0x00F0) >> 4; } }
+            public int nExtraA_comp3 { get { return (nExtraA & 0x0F00) >> 8; } }
 
-            public int nExtraAComp;
-            public int nExtraARule;
-            public int nExtraBComp;
-            public int nExtraBRule;
+            public int nExtraB_comp1 { get { return (nExtraB & 0x000F) >> 0; } }
+            public int nExtraB_comp2 { get { return (nExtraB & 0x00F0) >> 4; } }
+            public int nExtraB_comp3 { get { return (nExtraB & 0x0F00) >> 8; } }
 
-            public int nExtraA;
-            public int nExtraB;
+            public int nExtraAComp { get { return (nExtraA & 0x0FFF) >> 0; } }
+            public int nExtraARule { get { return (nExtraA & 0xF000) >> 12; } }
+            public int nExtraBComp { get { return (nExtraB & 0x0FFF) >> 0; } }
+            public int nExtraBRule { get { return (nExtraB & 0xF000) >> 12; } }
+
+            public int nExtraA { get { return (value & 0x0FFF) >> 0; } }
+            public int nExtraB { get { return (int)(value & 0xFFFF0000) >> 16; } }
 
             public CompRulesUnion(int value)
             {
-                nExtraA = (value & 0x0000FFFF) >> 0;
-                nExtraB = (int)(value & 0xFFFF0000) >> 16;
-
-                nExtraAComp = (nExtraA & 0x0FFF) >> 0;
-                nExtraARule = (nExtraA & 0xF000) >> 12;
-
-                nExtraBComp = (nExtraB & 0x0FFF) >> 0;
-                nExtraBRule = (nExtraB & 0xF000) >> 12;
-
-                nExtraA_comp1 = (nExtraA & 0x000F) >> 0;
-                nExtraA_comp2 = (nExtraA & 0x00F0) >> 4;
-                nExtraA_comp3 = (nExtraA & 0x0F00) >> 8;
-
-                nExtraB_comp1 = (nExtraB & 0x000F) >> 0;
-                nExtraB_comp2 = (nExtraB & 0x00F0) >> 4;
-                nExtraB_comp3 = (nExtraB & 0x0F00) >> 8;
+                this.value = value;
             }
 
             public Boolean HasExtraOne()

--- a/Assets/Scripts/Importing/Items/Definitions/VehicleDef.cs
+++ b/Assets/Scripts/Importing/Items/Definitions/VehicleDef.cs
@@ -22,7 +22,7 @@ namespace SanAndreasUnity.Importing.Items.Definitions
     {
         public struct CompRulesUnion
         {
-            private int value;
+            private readonly int value;
 
             public int nExtraA_comp1 { get { return (nExtraA & 0x000F) >> 0; } }
             public int nExtraA_comp2 { get { return (nExtraA & 0x00F0) >> 4; } }
@@ -37,7 +37,7 @@ namespace SanAndreasUnity.Importing.Items.Definitions
             public int nExtraBComp { get { return (nExtraB & 0x0FFF) >> 0; } }
             public int nExtraBRule { get { return (nExtraB & 0xF000) >> 12; } }
 
-            public int nExtraA { get { return (value & 0x0FFF) >> 0; } }
+            public int nExtraA { get { return (value & 0xFFFF) >> 0; } }
             public int nExtraB { get { return (int)(value & 0xFFFF0000) >> 16; } }
 
             public CompRulesUnion(int value)


### PR DESCRIPTION
As was noted at #86  , some vehicles have extra componets, which are being selected by a few different rules. Since the original impementations of those tricky rules used some bit operations, I used this a reversed implementation as a cheat-sheet (see `::ChooseComponent` method at [gta_reversed](https://github.com/codenulls/gta-reversed/blob/3cfeabd54aa9cefab3b8770aaec730d19b579e55/source/game_sa/Models/CVehicleModelInfo.cpp)

Now it works fine, and selects extra compontents according to rules explained in the topic: https://gtaforums.com/topic/530575-tutcomponent-rules/
The only exception is that rules should also consider current weather, which is not currenty implemented in the project.

As a possible improvement `int` can be replaced by `bytes` in my union-like struct, to save some memory. Unfortunately, I found no obvious way to work with separate 4 bits in C#, only with bytes, which are not really useful to parse values like 2ff0